### PR TITLE
fix ssh key when creating a new server

### DIFF
--- a/cloud-api-net/Api/Server.cs
+++ b/cloud-api-net/Api/Server.cs
@@ -257,7 +257,7 @@ namespace lkcode.hetznercloudapi.Api
             // optional field: ssh-key
             if (sshKeys != null && sshKeys.Length > 0)
             {
-                arguments.Add("ssh_keys", JsonConvert.SerializeObject(sshKeys));
+                arguments.Add("ssh_keys", sshKeys);
             }
             // optional field: user-data
             if (!string.IsNullOrEmpty(userData) && !string.IsNullOrWhiteSpace(userData))


### PR DESCRIPTION
When creating a new server, ssh keys are not accepted.
While debugging I noticed that by serializing several times, quotes are inserted as well.
Without this multiple serialization the names work.
IDs are not found.
Before, neither of these worked.